### PR TITLE
add gql # comment format

### DIFF
--- a/src/graphql-shorthand.pegjs
+++ b/src/graphql-shorthand.pegjs
@@ -41,7 +41,9 @@ EnumIdentList
     { return [head, ...tail]; }
 
 Comment
-  = "//" comment:(!EOL char:CHAR { return char; })* EOL_SEP
+  = "#" comment:(!EOL char:CHAR { return char; })* EOL_SEP
+    { return comment.join("").trim(); }
+  / "//" comment:(!EOL char:CHAR { return char; })* EOL_SEP
     { return comment.join("").trim(); }
   / "/*" comment:(!"*/" char:CHAR { return char; })* "*/" EOL_SEP
     { return comment.join("").replace(/\n\s*[*]?\s*/g, " ").replace(/\s+/, " ").trim(); }

--- a/test/comment.js
+++ b/test/comment.js
@@ -1,0 +1,52 @@
+import test from "ava";
+import { parse } from "..";
+
+test("add '#' comments as description", t => {
+  const [actual] = parse(`
+    # FOO as in Foobar
+    enum Bar { FOO }
+  `);
+
+  const expected = {
+    type: "ENUM",
+    name: "Bar",
+    description: "FOO as in Foobar",
+    values: ["FOO"]
+  };
+
+  return t.same(actual, expected);
+});
+
+test("add '//' comments as description", t => {
+  const [actual] = parse(`
+    // FOO as in Foobar
+    enum Bar { FOO }
+  `);
+
+  const expected = {
+    type: "ENUM",
+    name: "Bar",
+    description: "FOO as in Foobar",
+    values: ["FOO"]
+  };
+
+  return t.same(actual, expected);
+});
+
+test("add '/**/' comments as description", t => {
+  const [actual] = parse(`
+    /*
+      FOO as in Foobar
+    */
+    enum Bar { FOO }
+  `);
+
+  const expected = {
+    type: "ENUM",
+    name: "Bar",
+    description: "FOO as in Foobar",
+    values: ["FOO"]
+  };
+
+  return t.same(actual, expected);
+});


### PR DESCRIPTION
Add the official gql comment format `# <foobar>` see [spec](https://facebook.github.io/graphql/#sec-Comments)

Nice job by the way! I was looking for something simpler than graph.ql and this looks good.
