### PR TITLE
Relax rules for separators to be closer to GraphQL spec

### DIFF
--- a/src/graphql-shorthand.pegjs
+++ b/src/graphql-shorthand.pegjs
@@ -33,7 +33,7 @@ Field
     { return { [name]: { ...type, ...(args && { args }) } }; }
 
 FieldList
-  = head:Field tail:(EOL_SEP field:Field { return field; })*
+  = head:Field tail:(SEP field:Field { return field; })*
     { return [head, ...tail].reduce((result, field) => ({ ...result, ...field }), {}); }
 
 EnumIdentList
@@ -62,6 +62,8 @@ COLON = WS* ":" WS*
 
 COMMA_SEP = WS* "," WS*
 EOL_SEP = SPACE* EOL SPACE*
+
+SEP = (COMMA_SEP / EOL_SEP / WS)+
 
 SPACE = [ \t]+
 EOL = "\n" / "\r\n" / "\r" / "\u2028" / "\u2029"

--- a/src/graphql-shorthand.pegjs
+++ b/src/graphql-shorthand.pegjs
@@ -1,5 +1,5 @@
 start
-  = WS* definitions:(Enum / Interface / Object)* WS*
+  = SEP* definitions:(Enum / Interface / Object)* WS*
     { return definitions; }
 
 Ident = $([a-z]([a-z0-9_]i)*)
@@ -7,15 +7,15 @@ TypeIdent = $([A-Z]([a-z0-9_]i)*)
 EnumIdent = $([A-Z][A-Z0-9_]*)
 
 Enum
-  = description:Comment? "enum" SPACE name:TypeIdent BEGIN_BODY values:EnumIdentList CLOSE_BODY
+  = description:Comment? "enum" SEP name:TypeIdent BEGIN_BODY values:EnumIdentList CLOSE_BODY
     { return { type: "ENUM", name, ...(description && { description }), values }; }
 
 Interface
-  = description:Comment? "interface" SPACE name:TypeIdent BEGIN_BODY fields:FieldList CLOSE_BODY
+  = description:Comment? "interface" SEP name:TypeIdent BEGIN_BODY fields:FieldList CLOSE_BODY
     { return { type: "INTERFACE", name, ...(description && { description }), fields }; }
 
 Object
-  = description:Comment? "type" SPACE name:TypeIdent interfaces:(COLON list:TypeList { return list; })? BEGIN_BODY fields:FieldList CLOSE_BODY
+  = description:Comment? "type" SEP name:TypeIdent interfaces:(COLON list:TypeList { return list; })? BEGIN_BODY fields:FieldList CLOSE_BODY
     { return { type: "TYPE", name, ...(description && { description }), fields, ...(interfaces && { interfaces }) }; }
 
 ReturnType
@@ -25,7 +25,7 @@ ReturnType
     { return { type, list: true }; }
 
 TypeList
-  = head:TypeIdent tail:(COMMA_SEP type:TypeIdent { return type; })*
+  = head:TypeIdent tail:(SEP type:TypeIdent { return type; })*
     { return [head, ...tail]; }
 
 Field
@@ -37,7 +37,7 @@ FieldList
     { return [head, ...tail].reduce((result, field) => ({ ...result, ...field }), {}); }
 
 EnumIdentList
-  = head:EnumIdent tail:(EOL_SEP value:EnumIdent { return value; })*
+  = head:EnumIdent tail:(SEP value:EnumIdent { return value; })*
     { return [head, ...tail]; }
 
 Comment


### PR DESCRIPTION
Really cool library, thanks a lot for writing this!

I noticed that multiple arguments to a field currently have to be separated by EOL_SEP. Commas would be nicer, so I added those in the first commit. Now you can write:

```
type User {
  name: String
  profile_pic_url( height: Int, width: Int): String
}
```

Before, the only way was to add a newline (because arguments are FieldLists):

```
type User {
  name: String
  profile_pic_url( height: Int
                           width: Int): String
}
```

This got me thinking that you should be able to use either whitespace, newline or comma to separate fields. So the second commit aims to match the rules for separators to those in the GraphQL spec, where [lexical tokens can be separated by one or more comma, newline or whitespace](https://facebook.github.io/graphql/#sec-Source-Text.Ignored-Tokens). Maybe they intended it for the query language, but I think it should apply to the shorthand notation as well.
