### PR TITLE
Input object type

### DIFF
--- a/src/graphql-shorthand.pegjs
+++ b/src/graphql-shorthand.pegjs
@@ -5,6 +5,7 @@ start
 Ident = $([a-z]([a-z0-9_]i)*)
 TypeIdent = $([A-Z]([a-z0-9_]i)*)
 EnumIdent = $([A-Z][A-Z0-9_]*)
+NumberIdent = $([.+-]?[0-9]+([.][0-9]+)?)
 
 Enum
   = description:Comment? "enum" SPACE name:TypeIdent BEGIN_BODY values:EnumIdentList CLOSE_BODY
@@ -59,13 +60,20 @@ Comment
     { return comment.join("").replace(/\n\s*[*]?\s*/g, " ").replace(/\s+/, " ").trim(); }
 
 Literal
-  = StringLiteral
+  = StringLiteral / BooleanLiteral / NumericLiteral
 
 StringLiteral
   = '"' chars:DoubleStringCharacter* '"' { return chars.join(""); }
 
 DoubleStringCharacter
   = !('"' / "\\" / EOL) . { return text(); }
+
+BooleanLiteral
+  = "true"  { return true }
+  / "false"  { return false }
+
+NumericLiteral
+  = value:NumberIdent { return Number(value.replace(/^[.]/, '0.')); }
 
 LINE_COMMENT = "#" / "//"
 

--- a/test/input.js
+++ b/test/input.js
@@ -23,8 +23,26 @@ test("input definition", t => {
   return t.same(actual, expected);
 });
 
+test("input with boolean defaultValue", t => {
+  const [actual] = parse(`
+    input Person {
+      alive: Boolean = true
+    }
+  `);
 
-test("input with default values", t => {
+  const expected = {
+    type: "INPUT",
+    name: "Person",
+    fields: {
+      alive: { type: "Boolean", defaultValue: true },
+    }
+  };
+
+  return t.same(actual, expected);
+});
+
+
+test("input with string default values", t => {
   const [actual] = parse(`
     // A Person
     input Person {
@@ -48,3 +66,40 @@ test("input with default values", t => {
   return t.same(actual, expected);
 });
 
+test("input with integer defaultValue", t => {
+  const [actual] = parse(`
+    input Person {
+      age: Int = 32
+    }
+  `);
+
+  const expected = {
+    type: "INPUT",
+    name: "Person",
+    fields: {
+      age: { type: "Int", defaultValue: 32 },
+    }
+  };
+
+  return t.same(actual, expected);
+});
+
+test("input with float defaultValue", t => {
+  const [actual] = parse(`
+    input Person {
+      height: Float = 1.82
+      iq: Float = .5
+    }
+  `);
+
+  const expected = {
+    type: "INPUT",
+    name: "Person",
+    fields: {
+      height: { type: "Float", defaultValue: 1.82 },
+      iq: { type: "Float", defaultValue: 0.5 },
+    }
+  };
+
+  return t.same(actual, expected);
+});

--- a/test/input.js
+++ b/test/input.js
@@ -6,6 +6,7 @@ test("input definition", t => {
     // A Person
     input Person {
       id: String!
+      // The full name
       name: String
     }
   `);
@@ -16,7 +17,7 @@ test("input definition", t => {
     description: "A Person",
     fields: {
       id: { type: "String", required: true },
-      name: { type: "String" }
+      name: { type: "String", description: "The full name" }
     }
   };
 

--- a/test/input.js
+++ b/test/input.js
@@ -1,0 +1,50 @@
+import test from "ava";
+import { parse } from "..";
+
+test("input definition", t => {
+  const [actual] = parse(`
+    // A Person
+    input Person {
+      id: String!
+      name: String
+    }
+  `);
+
+  const expected = {
+    type: "INPUT",
+    name: "Person",
+    description: "A Person",
+    fields: {
+      id: { type: "String", required: true },
+      name: { type: "String" }
+    }
+  };
+
+  return t.same(actual, expected);
+});
+
+
+test("input with default values", t => {
+  const [actual] = parse(`
+    // A Person
+    input Person {
+      id: String!
+      firstname: String = "Hans"
+      lastname: String = "Wurst"
+    }
+  `);
+
+  const expected = {
+    type: "INPUT",
+    name: "Person",
+    description: "A Person",
+    fields: {
+      id: { type: "String", required: true },
+      firstname: { type: "String", defaultValue: "Hans" },
+      lastname: { type: "String", defaultValue: "Wurst" }
+    }
+  };
+
+  return t.same(actual, expected);
+});
+


### PR DESCRIPTION
Adds the `input` type definition including a `defaultValue` property. 

```
input Person {
  name: String = "Hans"
  age: Int = 32
  size: Float = 1.82
  funny: Boolean = true
}
```

returns:

```
{
  type: "INPUT",
  name: "Person",
  fields: {
    name: { type: "String", defaultValue: "Hans" },
    age: { type: "Int", defaultValue: 32 },
    size: { type: "Float", defaultValue: 1.82 }
    funny: { type: "Boolean", defaultValue: true }
  }
```

  }

Strings must use double quotes `"`
Floats can omit leading zeros (`.5` => `0.5`)
Boolean values must be lower-case
